### PR TITLE
Extend testCaseListener with method reflection and applicationContainer

### DIFF
--- a/src/ITestCaseListener.php
+++ b/src/ITestCaseListener.php
@@ -2,9 +2,11 @@
 
 namespace Mangoweb\Tester\Infrastructure;
 
+use Nette\DI\Container;
+
 interface ITestCaseListener
 {
-	public function setUp(TestCase $testCase): void;
+	public function setUp(TestCase $testCase, Container $applicationContainer, \ReflectionMethod $testMethod): void;
 
-	public function tearDown(TestCase $testCase): void;
+	public function tearDown(TestCase $testCase, Container $applicationContainer, \ReflectionMethod $testMethod): void;
 }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -100,12 +100,12 @@ class TestCase
 	}
 
 
-	protected function executeSetupListeners(): void
+	protected function executeSetupListeners(\ReflectionMethod $method): void
 	{
 		foreach ($this->testContainer->findByType(ITestCaseListener::class) as $serviceName) {
 			$service = $this->testContainer->getService($serviceName);
 			assert($service instanceof ITestCaseListener);
-			$service->setUp($this);
+			$service->setUp($this, $this->applicationContainer,$method);
 		}
 	}
 
@@ -118,12 +118,12 @@ class TestCase
 	}
 
 
-	protected function executeTearDownListeners(): void
+	protected function executeTearDownListeners(\ReflectionMethod $method): void
 	{
 		foreach ($this->testContainer->findByType(ITestCaseListener::class) as $serviceName) {
 			$service = $this->testContainer->getService($serviceName);
 			assert($service instanceof ITestCaseListener);
-			$service->tearDown($this);
+			$service->tearDown($this, $this->applicationContainer, $method);
 		}
 	}
 
@@ -145,7 +145,7 @@ class TestCase
 		try {
 			$this->applicationContainer->callInjects($this);
 
-			$this->executeSetupListeners();
+			$this->executeSetupListeners($method);
 			$this->setUp();
 
 			$this->handleErrors = TRUE;
@@ -159,7 +159,7 @@ class TestCase
 			$this->handleErrors = FALSE;
 
 			$this->tearDown();
-			$this->executeTearDownListeners();
+			$this->executeTearDownListeners($method);
 
 			return $result;
 		} catch (AssertException $e) {


### PR DESCRIPTION
Feature: yes
BC Break: yes

This PR append information about a method before/after which is executed. It is suitable for reading PhpDoc (for example for changing database mode by annotation).  
It also appends application container for pass full knowledge about testing env.