### PR TITLE
Fixed compatibility with Nette\Tester 2.1

### DIFF
--- a/src/TestCaseRunner.php
+++ b/src/TestCaseRunner.php
@@ -63,7 +63,7 @@ class TestCaseRunner
 			throw new TestCaseException("Method {$method->getName()} is not public. Make it public or rename it.");
 		}
 
-		$info = \Tester\Helpers::parseDocComment($method->getDocComment()) + ['dataprovider' => NULL];
+		$info = \Tester\Helpers::parseDocComment($method->getDocComment() ?? '') + ['dataprovider' => NULL];
 
 		$data = [];
 		$defaultParams = [];


### PR DESCRIPTION
In `nette/tester` version `2.1`, scalar typehints was added:
```php
public static function parseDocComment(string $s): array
```
and so calling `Tester\Helpers::parseDocComment()` ends as error:
```
TypeError: Argument 1 passed to Tester\Helpers::parseDocComment() must be of the type string, boolean given, called in mangoweb/tester-infrastructure/src/TestCaseRunner.php on line 66
```
